### PR TITLE
feat: Add a simp lemma `Nat.cast x = BitVec.ofNat _ x`

### DIFF
--- a/Std/Data/BitVec/Basic.lean
+++ b/Std/Data/BitVec/Basic.lean
@@ -100,6 +100,7 @@ instance : ToString (BitVec n) where toString a := toString (repr a)
 /-- Theorem for normalizing the bit vector literal representation. -/
 -- TODO: This needs more usage data to assess which direction the simp should go.
 @[simp] theorem ofNat_eq_ofNat : @OfNat.ofNat (BitVec n) i _ = BitVec.ofNat n i := rfl
+@[simp] theorem natCast_eq_ofNat : Nat.cast x = x#w := rfl
 
 /--
 Addition for bit vectors. This can be interpreted as either signed or unsigned addition


### PR DESCRIPTION
We already have a simp lemma that rewrites `OfNat.ofNat` into `BitVec.ofNat`.
This PR extends that by rewriting `Nat.cast` into `BitVec.ofNat` as well, making `BitVec.ofNat` the canonical simp-normal form for all ways to turn a `Nat` into a `BitVec`.