### PR TITLE
feat: establish `allOnes` as simp normal form

### DIFF
--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -234,6 +234,9 @@ private theorem allOnes_def :
   else
     simp [h]
 
+@[simp] theorem negOne_eq_allOnes : -1#w = allOnes w :=
+  rfl
+
 /-! ### or -/
 
 @[simp] theorem toNat_or (x y : BitVec v) :


### PR DESCRIPTION
Adds a lemma `negOne_eq_allOnes`, ensuring that `(-1 : BitVec w)` and `-1#w` are both (transitively) simplified to `allOnes w`.