### PR TITLE
Teach omega that `b^(e+1) = b*b^e` when `b` is a constant.

### DIFF
--- a/Std/Tactic/Omega/Int.lean
+++ b/Std/Tactic/Omega/Int.lean
@@ -28,6 +28,8 @@ theorem pos_pow_of_pos (a : Int) (b : Nat) (h : 0 < a) : 0 < a ^ b := by
   rw [Int.eq_natAbs_of_zero_le (Int.le_of_lt h), ← Int.ofNat_zero, ← Int.ofNat_pow, Int.ofNat_lt]
   exact Nat.pos_pow_of_pos _ (Int.natAbs_pos.mpr (Int.ne_of_gt h))
 
+theorem pow_succ (b : Int) (e : Nat) : b ^ e.succ = (b ^ e) * b := rfl
+
 theorem ofNat_pos {a : Nat} : 0 < (a : Int) ↔ 0 < a := by
   rw [← Int.ofNat_zero, Int.ofNat_lt]
 

--- a/test/omega/test.lean
+++ b/test/omega/test.lean
@@ -389,6 +389,6 @@ example (x e : Nat) (hx : x < 2^(e+1)) : x < 2^e *2 := by omega
 example (x e : Nat) (hx : x < 2^(e.succ)) : x < 2^e *2 := by omega
 
 -- Check that this works for integer base.
-example (x : Int) (e : Nat) (hx : x < 2^(e+1)) : x < 2^e *2 := by omega
+example (x : Int) (e : Nat) (hx : x < (2 : Int)^(e+1)) : x < 2^e *2 := by omega
 
 example (x y z i : Nat) (hz : z ≤ 1) : x % 2 ^ i + y % 2 ^ i + z < 2 * 2^ i := by omega

--- a/test/omega/test.lean
+++ b/test/omega/test.lean
@@ -382,4 +382,13 @@ example (i j : Nat) (p : i ≥ j) : True := by
 
 example (i : Fin 7) : (i : Nat) < 8 := by omega
 
+-- Check that we correctly process base^(e+1) for constant base.
+example (x e : Nat) (hx : x < 2^(e+1)) : x < 2^e *2 := by omega
+
+-- Check that we correctly handle `e.succ`
+example (x e : Nat) (hx : x < 2^(e.succ)) : x < 2^e *2 := by omega
+
+-- Check that this works for integer base.
+example (x : Int) (e : Nat) (hx : x < 2^(e+1)) : x < 2^e *2 := by omega
+
 example (x y z i : Nat) (hz : z ≤ 1) : x % 2 ^ i + y % 2 ^ i + z < 2 * 2^ i := by omega


### PR DESCRIPTION
This is very helpful when dealing with bitvectors, where a case analysis on the bitwidth leaves one with hypotheses of the form `x<2^(Nat.succ w)`.