### PR TITLE
feat: prove `Fin.add_rev_eq_last'`, adding a `i : Fin n` to its inverse `i.rev` always yields the greatest element, `Fin.last' _`

### DIFF
--- a/Std/Data/BitVec/Bitblast.lean
+++ b/Std/Data/BitVec/Bitblast.lean
@@ -158,15 +158,3 @@ theorem adc_spec (x y : BitVec w) (c : Bool) :
 
 theorem add_eq_adc (w : Nat) (x y : BitVec w) : x + y = (adc x y false).snd := by
   simp [adc_spec]
-
-/-! ### add -/
-
-/-- Adding a bitvector to its own complement yields the all ones bitpattern -/
-@[simp] theorem add_not_self (x : BitVec w) : x + ~~~x = allOnes w := by
-  rw [add_eq_adc, adc, iunfoldr_replace (fun _ => false) (allOnes w)]
-  · rfl
-  · simp [adcb, atLeastTwo]
-
-/-- Subtracting `x` from the all ones bitvector is equivalent to taking its complement -/
-theorem allOnes_sub_eq_not (x : BitVec w) : allOnes w - x = ~~~x := by
-  rw [← add_not_self x, BitVec.add_comm, add_sub_cancel]

--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -236,6 +236,9 @@ private theorem allOnes_def :
   else
     simp [h]
 
+@[simp] theorem toFin_allOnes : (allOnes w).toFin = Fin.last' (Nat.two_pow_pos _) := by
+  apply Fin.eq_of_val_eq; simp
+
 /-! ### or -/
 
 @[simp] theorem toNat_or (x y : BitVec v) :
@@ -446,6 +449,9 @@ protected theorem add_comm (x y : BitVec n) : x + y = y + x := by
 
 @[simp] protected theorem zero_add (x : BitVec n) : 0#n + x = x := by simp [add_def]
 
+/-- Adding a bitvector to its own complement yields the all ones bitpattern -/
+@[simp] theorem add_not_self (x : BitVec w) : x + ~~~x = allOnes w := by
+  apply eq_of_toFin_eq; simp [Fin.add_rev_eq_last', toFin_allOnes]
 
 /-! ### sub/neg -/
 
@@ -491,6 +497,10 @@ theorem add_sub_cancel (x y : BitVec w) : x + y - y = x := by
   have y_toNat_le := Nat.le_of_lt y.toNat_lt
   rw [toNat_sub, toNat_add, Nat.mod_add_mod, Nat.add_assoc, ← Nat.add_sub_assoc y_toNat_le,
     Nat.add_sub_cancel_left, Nat.add_mod_right, toNat_mod_cancel]
+
+/-- Subtracting `x` from the all ones bitvector is equivalent to taking its complement -/
+theorem allOnes_sub_eq_not (x : BitVec w) : allOnes w - x = ~~~x := by
+  rw [← add_not_self x, BitVec.add_comm, add_sub_cancel]
 
 /-! ### mul -/
 

--- a/Std/Data/Fin/Basic.lean
+++ b/Std/Data/Fin/Basic.lean
@@ -13,6 +13,9 @@ protected theorem pos (i : Fin n) : 0 < n :=
 /-- The greatest value of `Fin (n+1)`. -/
 @[inline] def last (n : Nat) : Fin (n + 1) := ⟨n, n.lt_succ_self⟩
 
+/-- The greatest value of `Fin n`, given that `0 < n` -/
+@[inline] def last' (h : 0 < n) : Fin n := ⟨n - 1, Nat.sub_lt h Nat.zero_lt_one⟩
+
 /-- `castLT i h` embeds `i` into a `Fin` where `h` proves it belongs into.  -/
 @[inline] def castLT (i : Fin m) (h : i.1 < n) : Fin n := ⟨i.1, h⟩
 

--- a/Std/Data/Fin/Lemmas.lean
+++ b/Std/Data/Fin/Lemmas.lean
@@ -762,9 +762,10 @@ theorem add_assoc (i j k : Fin n) : i + j + k = i + (j + k) := by
 
 theorem add_rev_eq_last' (i : Fin n) : i + i.rev = Fin.last' i.pos := by
   apply eq_of_val_eq
+  have := i.pos
   rw [Fin.val_add, Fin.val_rev, Fin.val_last', Nat.sub_add_eq, ← Nat.add_sub_assoc,
     ← Nat.add_sub_assoc, Nat.add_sub_cancel_left, Nat.mod_eq_of_lt]
-  <;> (have := i.pos; omega)
+  <;> omega
 
 /-! ### sub -/
 

--- a/Std/Data/Fin/Lemmas.lean
+++ b/Std/Data/Fin/Lemmas.lean
@@ -170,6 +170,16 @@ theorem val_lt_last {i : Fin (n + 1)} : i ≠ last n → (i : Nat) < n :=
 @[simp] theorem rev_zero (n : Nat) : rev 0 = last n := by
   rw [← rev_rev (last _), rev_last]
 
+/-- Rewrite `@last' (n+1) _` to `last n` -/
+theorem last'_eq_last (n : Nat) : last' (by simp) = last n := rfl
+
+@[simp]
+theorem val_last' {h : 0 < n} : (Fin.last' h).val = n-1 := by
+  cases n
+  · contradiction
+  · simp [last'_eq_last]
+
+
 /-! ### addition, numerals, and coercion from Nat -/
 
 @[simp] theorem val_one (n : Nat) : (1 : Fin (n + 2)).val = 1 := rfl
@@ -734,6 +744,12 @@ theorem addCases_right {m n : Nat} {motive : Fin (m + n) → Sort _} {left right
 
 /-! ### add -/
 
+@[simp] theorem zero_add (i : Fin (n+1)) : 0 + i = i := by
+  apply eq_of_val_eq; simp [val_add, Nat.mod_eq_of_lt]
+
+theorem add_assoc (i j k : Fin n) : i + j + k = i + (j + k) := by
+  simp [← val_inj, val_add, Nat.add_assoc]
+
 @[simp] theorem ofNat'_add (x : Nat) (lt : 0 < n) (y : Fin n) :
     Fin.ofNat' x lt + y = Fin.ofNat' (x + y.val) lt := by
   apply Fin.eq_of_val_eq
@@ -743,6 +759,12 @@ theorem addCases_right {m n : Nat} {motive : Fin (m + n) → Sort _} {left right
     x + Fin.ofNat' y lt = Fin.ofNat' (x.val + y) lt := by
   apply Fin.eq_of_val_eq
   simp [Fin.ofNat', Fin.add_def]
+
+theorem add_rev_eq_last' (i : Fin n) : i + i.rev = Fin.last' i.pos := by
+  apply eq_of_val_eq
+  rw [Fin.val_add, Fin.val_rev, Fin.val_last', Nat.sub_add_eq, ← Nat.add_sub_assoc,
+    ← Nat.add_sub_assoc, Nat.add_sub_cancel_left, Nat.mod_eq_of_lt]
+  <;> (have := i.pos; omega)
 
 /-! ### sub -/
 


### PR DESCRIPTION
This proves that for all `i : Fin n`, `i + i.rev` is equal to the greatest element of `Fin n`.
Usually, this greatest element is spelled `Fin.last n : Fin (n+1)`, but because we want to be able to apply this lemma in cases where `n` is not of the shape `_ + 1`, we also add an alternative spelling
```lean
/-- The greatest value of `Fin n`, given that `0 < n` -/
def Fin.last' (h : 0 < n) : Fin n
```

Finally, we relate this to bitvectors: showing that `(allOnes w).toFin = Fin.last' (_ : 0 < 2^w)`, and thus making `add_not_self` a direct corollary of `Fin.add_rev_eq_last`. This replaces the previous proof relying on the alternative characterization of addition with `adc`.
```lean
theorem add_not_self (x : BitVec w) : x + ~~~x = allOnes w
```

