### PR TITLE
feat: add `BitVec.eq_of_toInt_eq` lemma

### DIFF
--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -82,6 +82,20 @@ theorem eq_of_getMsb_eq {x y : BitVec w}
 theorem eq_of_toFin_eq : ∀ {x y : BitVec w}, x.toFin = y.toFin → x = y
   | ⟨_, _⟩, ⟨_, _⟩, rfl => rfl
 
+theorem eq_of_toInt_eq {x y : BitVec w} : x.toInt = y.toInt → x = y := by
+  simp only [BitVec.toInt, Int.ofNat_eq_coe, ← Int.subNatNat_eq_coe, Int.subNatNat_of_lt x.toNat_lt,
+    Int.subNatNat_of_lt y.toNat_lt]
+  intro h
+  apply eq_of_toNat_eq
+  cases hxm : x.msb <;> cases hym : y.msb <;> (simp only [↓reduceIte, hxm, hym] at h)
+  · apply Int.ofNat_inj.mp h
+  · have h : 2 ^ w - x.toNat = 2 ^ w - y.toNat :=
+      Nat.pred_inj (Nat.sub_pos_of_lt x.toNat_lt) (Nat.sub_pos_of_lt y.toNat_lt) <|
+          Int.negSucc.injEq _ _ ▸ h
+    have := Nat.eq_add_of_sub_eq (Nat.le_of_lt x.toNat_lt) h
+    have := Nat.eq_add_of_sub_eq (Nat.le_of_lt y.toNat_lt) h.symm
+    omega
+
 @[simp] theorem toNat_ofBool (b : Bool) : (ofBool b).toNat = b.toNat := by
   cases b <;> rfl
 


### PR DESCRIPTION
Prove that `BitVec.toInt` is injective. This will be useful to lifting properties we know to be true about `Int`s to bitvectors.