### PR TITLE
feat: show basic properties of `BitVec` multipication

### DIFF
--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -496,7 +496,7 @@ theorem add_sub_cancel (x y : BitVec w) : x + y - y = x := by
 
 theorem mul_def {n} {x y : BitVec n} : x * y = (ofFin <| x.toFin * y.toFin) := by rfl
 
-theorem toNat_mul (x y : BitVec n) : (x * y).toNat = (x.toNat * y.toNat) % 2 ^ n := rfl
+@[simp] theorem toNat_mul (x y : BitVec n) : (x * y).toNat = (x.toNat * y.toNat) % 2 ^ n := rfl
 @[simp] theorem toFin_mul (x y : BitVec n) : (x * y).toFin = (x.toFin * y.toFin) := rfl
 
 theorem mul_comm (x y : BitVec w) : x * y = y * x := by
@@ -506,6 +506,16 @@ instance : Std.Commutative (fun (x y : BitVec w) => x * y) := ⟨mul_comm⟩
 theorem mul_assoc (x y z : BitVec w) : x * y * z = x * (y * z) := by
   apply eq_of_toFin_eq; simpa using Fin.mul_assoc ..
 instance : Std.Associative (fun (x y : BitVec w) => x * y) := ⟨mul_assoc⟩
+
+theorem mul_one (x : BitVec w) : x * 1#w = x := by
+  cases w
+  · apply Subsingleton.elim
+  · apply eq_of_toNat_eq; simp [Nat.mod_eq_of_lt]
+theorem one_mul (x : BitVec w) : 1#w * x = x := by
+  rw [mul_comm, mul_one]
+
+instance : Std.LawfulCommIdentity (fun (x y : BitVec w) => x * y) (1#w) where
+  right_id := mul_one
 
 /-! ### le and lt -/
 

--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -501,9 +501,11 @@ theorem toNat_mul (x y : BitVec n) : (x * y).toNat = (x.toNat * y.toNat) % 2 ^ n
 
 theorem mul_comm (x y : BitVec w) : x * y = y * x := by
   apply eq_of_toFin_eq; simpa using Fin.mul_comm ..
+instance : Std.Commutative (fun (x y : BitVec w) => x * y) := ⟨mul_comm⟩
 
 theorem mul_assoc (x y z : BitVec w) : x * y * z = x * (y * z) := by
   apply eq_of_toFin_eq; simpa using Fin.mul_assoc ..
+instance : Std.Associative (fun (x y : BitVec w) => x * y) := ⟨mul_assoc⟩
 
 /-! ### le and lt -/
 

--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -499,6 +499,12 @@ theorem mul_def {n} {x y : BitVec n} : x * y = (ofFin <| x.toFin * y.toFin) := b
 theorem toNat_mul (x y : BitVec n) : (x * y).toNat = (x.toNat * y.toNat) % 2 ^ n := rfl
 @[simp] theorem toFin_mul (x y : BitVec n) : (x * y).toFin = (x.toFin * y.toFin) := rfl
 
+theorem mul_comm (x y : BitVec w) : x * y = y * x := by
+  apply eq_of_toFin_eq; simpa using Fin.mul_comm ..
+
+theorem mul_assoc (x y z : BitVec w) : x * y * z = x * (y * z) := by
+  apply eq_of_toFin_eq; simpa using Fin.mul_assoc ..
+
 /-! ### le and lt -/
 
 theorem le_def (x y : BitVec n) :

--- a/Std/Data/BitVec/Lemmas.lean
+++ b/Std/Data/BitVec/Lemmas.lean
@@ -499,23 +499,23 @@ theorem mul_def {n} {x y : BitVec n} : x * y = (ofFin <| x.toFin * y.toFin) := b
 @[simp] theorem toNat_mul (x y : BitVec n) : (x * y).toNat = (x.toNat * y.toNat) % 2 ^ n := rfl
 @[simp] theorem toFin_mul (x y : BitVec n) : (x * y).toFin = (x.toFin * y.toFin) := rfl
 
-theorem mul_comm (x y : BitVec w) : x * y = y * x := by
+protected theorem mul_comm (x y : BitVec w) : x * y = y * x := by
   apply eq_of_toFin_eq; simpa using Fin.mul_comm ..
-instance : Std.Commutative (fun (x y : BitVec w) => x * y) := ⟨mul_comm⟩
+instance : Std.Commutative (fun (x y : BitVec w) => x * y) := ⟨BitVec.mul_comm⟩
 
-theorem mul_assoc (x y z : BitVec w) : x * y * z = x * (y * z) := by
+protected theorem mul_assoc (x y z : BitVec w) : x * y * z = x * (y * z) := by
   apply eq_of_toFin_eq; simpa using Fin.mul_assoc ..
-instance : Std.Associative (fun (x y : BitVec w) => x * y) := ⟨mul_assoc⟩
+instance : Std.Associative (fun (x y : BitVec w) => x * y) := ⟨BitVec.mul_assoc⟩
 
-theorem mul_one (x : BitVec w) : x * 1#w = x := by
+@[simp] protected theorem mul_one (x : BitVec w) : x * 1#w = x := by
   cases w
   · apply Subsingleton.elim
   · apply eq_of_toNat_eq; simp [Nat.mod_eq_of_lt]
-theorem one_mul (x : BitVec w) : 1#w * x = x := by
-  rw [mul_comm, mul_one]
+@[simp] protected theorem one_mul (x : BitVec w) : 1#w * x = x := by
+  rw [BitVec.mul_comm, BitVec.mul_one]
 
 instance : Std.LawfulCommIdentity (fun (x y : BitVec w) => x * y) (1#w) where
-  right_id := mul_one
+  right_id := BitVec.mul_one
 
 /-! ### le and lt -/
 

--- a/Std/Data/Fin/Lemmas.lean
+++ b/Std/Data/Fin/Lemmas.lean
@@ -807,6 +807,12 @@ protected theorem mul_zero (k : Fin (n + 1)) : k * 0 = 0 := by simp [ext_iff, mu
 protected theorem zero_mul (k : Fin (n + 1)) : (0 : Fin (n + 1)) * k = 0 := by
   simp [ext_iff, mul_def]
 
+protected theorem mul_assoc (a b c : Fin n) : a * b * c = a * (b * c) := by
+  apply eq_of_val_eq
+  simp only [val_mul]
+  rw [← Nat.mod_eq_of_lt a.isLt, ← Nat.mod_eq_of_lt b.isLt, ← Nat.mod_eq_of_lt c.isLt]
+  simp only [← Nat.mul_mod, Nat.mul_assoc]
+
 end Fin
 
 namespace USize


### PR DESCRIPTION
Show that multiplication of bitvectors is associative and commutative, and show that it has `1#w` as identity.

Also adds `@[simp]` attribute to the existing lemma `toNat_mul`, as we have done for other `toNat_` lemmas